### PR TITLE
Handle uint8 better

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - wget https://raw.githubusercontent.com/jabooth/condaci/v0.2.0/condaci.py -O condaci.py
 - python condaci.py setup $PYTHON_VERSION --channel $BINSTAR_USER
 - export PATH=$HOME/miniconda/bin:$PATH
-#- conda config --add channels $BINSTAR_USER/channel/master
+- conda config --add channels $BINSTAR_USER/channel/master
 
 script:
 - python condaci.py auto ./conda --binstaruser $BINSTAR_USER --binstarkey $BINSTAR_KEY

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ platform:
 init:
 - ps: Start-FileDownload 'https://raw.githubusercontent.com/jabooth/condaci/v0.2.0/condaci.py' C:\\condaci.py; echo "Done"
 - cmd: python C:\\condaci.py setup %PYTHON_VERSION% --channel %BINSTAR_USER%
-#- cmd: C:\\Miniconda\\Scripts\\conda config --add channels %BINSTAR_USER%/channel/master
+- cmd: C:\\Miniconda\\Scripts\\conda config --add channels %BINSTAR_USER%/channel/master
 
 install:
 - cmd: C:\\Miniconda\\python C:\\condaci.py auto ./conda --binstaruser %BINSTAR_USER% --binstarkey %BINSTAR_KEY%

--- a/menpodetect/detect.py
+++ b/menpodetect/detect.py
@@ -18,8 +18,15 @@ def _greyscale(image):
     -------
     image : `menpo.image.Image`
         A greyscale version of the image.
+
+    Raises
+    ------
+    ValueError
+        uint8 images cannot be converted to Greyscale
     """
     if image.n_channels > 1:
+        if image.pixels.dtype == np.uint8:
+            raise ValueError('uint8 images cannot be converted to greyscale')
         if image.n_channels == 3:
             # Use luminosity for RGB images
             image = image.as_greyscale(mode='luminosity')
@@ -37,14 +44,18 @@ def menpo_image_to_uint8(image):
     Parameters
     ----------
     image : `menpo.image.Image`
-        The image to convert.
+        The image to convert. If already uint8, only the channels will be
+        rolled to the last axis.
 
     Returns
     -------
     uint8_image : `ndarray`
-        `uint8` Numpy array.
+        `uint8` Numpy array, channels as the back (last) axis.
     """
-    return np.array(image.as_PILImage())
+    if image.pixels.dtype == np.uint8:
+        return image.rolled_channels()
+    else:
+        return np.array(image.as_PILImage())
 
 
 def detect(detector_callable, image, greyscale=True,
@@ -56,11 +67,15 @@ def detect(detector_callable, image, greyscale=True,
     the image to a given diagonal, performing the detection, and attaching
     the scaled landmarks back onto the original image.
 
+    uint8 images cannot be converted to greyscale by this framework, so must
+    already be greyscale or ``greyscale=False``.
+
     Parameters
     ----------
     detector_callable : `callable` or `function`
         A callable object that will perform detection given a single parameter,
-        a `uint8` numpy array.
+        a `uint8` numpy array with either no channels, or channels as the
+        *last* axis.
     image : `menpo.image.Image`
         A Menpo image to detect. The bounding boxes of the detected objects
         will be attached to this image.

--- a/menpodetect/tests/detector_test.py
+++ b/menpodetect/tests/detector_test.py
@@ -3,9 +3,11 @@ from menpodetect.detect import detect
 import menpo.io as mio
 import numpy as np
 from numpy.testing import assert_allclose
+from nose.tools import raises
 
 
 takeo = mio.import_builtin_asset.takeo_ppm()
+takeo_uint8 = mio.import_image(mio.data_path_to('takeo.ppm'), normalise=False)
 fake_box = np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
 fake_detector = lambda x: ([PointDirectedGraph(
     fake_box.copy(),
@@ -21,3 +23,17 @@ def test_rescaling_image():
     assert takeo_copy.landmarks['object_0'][None].n_points == 4
     assert_allclose(takeo_copy.landmarks['object_0'][None].points,
                     fake_box * (1.0 / ratio), atol=10e-2)
+
+
+def test_passing_uint8_image():
+    takeo_copy = takeo_uint8.copy()
+    pcs = detect(fake_detector, takeo_copy, greyscale=False)
+    assert len(pcs) == 1
+    assert takeo_copy.n_channels == 3
+    assert takeo_copy.landmarks['object_0'][None].n_points == 4
+
+
+@raises(ValueError)
+def test_passing_uint8_image_greyscale_raises():
+    takeo_copy = takeo_uint8.copy()
+    pcs = detect(fake_detector, takeo_copy, greyscale=True)


### PR DESCRIPTION
Give better warning for RGB uint8 images (we can't convert them
automatically to greyscale), and allow better pass through of
the data.

Also relies on the new ``rolled_channels`` method, so have to wait for that before we can merge.