### PR TITLE
Python310 builds

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,7 +37,7 @@ test:
     - menpodetect.opencv
 
   commands:
-    - pytest $SP_DIR/menpodetect -v --cov=menpodetect --cov-conftig .coveragerc
+    - pytest $SP_DIR/menpodetect -v --cov=menpodetect --cov-config .coveragerc
 
 about:
   home: https://github.com/menpo/menpodetect/

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,6 +26,7 @@ test:
     - pytest-cov >=2.0,<3.0
     - pytest-mock >=3.0,<4.0
     - black >= 20.0
+    - libopencv *=headless*  # [linux]
 
   files:
     - .coveragerc
@@ -36,7 +37,7 @@ test:
     - menpodetect.opencv
 
   commands:
-    - pytest $SP_DIR/menpodetect -v --cov=menpodetect --cov-config .coveragerc
+    - pytest $SP_DIR/menpodetect -v --cov=menpodetect --cov-conftig .coveragerc
 
 about:
   home: https://github.com/menpo/menpodetect/


### PR DESCRIPTION
[The fix for headless OpenCV was flagged here](https://github.com/conda-forge/opencv-feedstock/issues/401)

This is actually affecting menpo upstream but our import chains are guarded against it